### PR TITLE
Add PR automation workflow and expand MCP server catalogue

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -1,0 +1,134 @@
+name: PR Automation
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "Which pull request operation should run"
+        required: true
+        type: choice
+        options:
+          - create
+          - approve
+          - run-tests
+      head:
+        description: "Head branch for the PR (create action only)"
+        required: false
+        type: string
+      base:
+        description: "Base branch for the PR (create action only)"
+        required: false
+        type: string
+      title:
+        description: "Pull request title (create action only)"
+        required: false
+        type: string
+      body:
+        description: "Pull request body (create action only)"
+        required: false
+        type: string
+      pr-number:
+        description: "Pull request number (approve/run-tests actions)"
+        required: false
+        type: string
+      review-body:
+        description: "Optional approval note (approve action only)"
+        required: false
+        type: string
+
+permissions:
+  actions: write
+  checks: write
+  contents: write
+  deployments: write
+  discussions: write
+  issues: write
+  packages: write
+  pull-requests: write
+  repository-projects: write
+  security-events: write
+  statuses: write
+
+jobs:
+  run-command:
+    name: Execute pull request automation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install GitHub CLI
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gh
+
+      - name: Validate inputs
+        env:
+          ACTION: ${{ github.event.inputs.action }}
+          HEAD: ${{ github.event.inputs.head }}
+          BASE: ${{ github.event.inputs.base }}
+          TITLE: ${{ github.event.inputs.title }}
+          BODY: ${{ github.event.inputs.body }}
+          PR_NUMBER: ${{ github.event.inputs.pr-number }}
+        run: |
+          set -euo pipefail
+          case "$ACTION" in
+            create)
+              for var in HEAD BASE TITLE; do
+                if [ -z "${!var}" ]; then
+                  echo "::error::Missing required input '$var' for create action"
+                  exit 1
+                fi
+              done
+              ;;
+            approve|run-tests)
+              if [ -z "$PR_NUMBER" ]; then
+                echo "::error::pr-number is required for the $ACTION action"
+                exit 1
+              fi
+              ;;
+            *)
+              echo "::error::Unsupported action '$ACTION'"
+              exit 1
+              ;;
+          esac
+
+      - name: Execute request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTION: ${{ github.event.inputs.action }}
+          HEAD: ${{ github.event.inputs.head }}
+          BASE: ${{ github.event.inputs.base }}
+          TITLE: ${{ github.event.inputs.title }}
+          BODY: ${{ github.event.inputs.body }}
+          PR_NUMBER: ${{ github.event.inputs.pr-number }}
+          REVIEW_BODY: ${{ github.event.inputs.review-body }}
+        run: |
+          set -euo pipefail
+          case "$ACTION" in
+            create)
+              gh pr create \
+                --head "$HEAD" \
+                --base "$BASE" \
+                --title "$TITLE" \
+                ${BODY:+--body "$BODY"}
+              ;;
+            approve)
+              gh pr review "$PR_NUMBER" --approve ${REVIEW_BODY:+--body "$REVIEW_BODY"}
+              ;;
+            run-tests)
+              gh pr checkout "$PR_NUMBER"
+              python -m compileall configure_spaces_mcp.py
+              python configure_spaces_mcp.py --list-only
+              ;;
+          esac
+
+      - name: Upload MCP catalogue snapshot
+        if: github.event.inputs.action == 'run-tests'
+        uses: actions/upload-artifact@v4
+        with:
+          name: mcp-spaces
+          path: mcp_spaces.json
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 Utility scripts for experimenting with agent orchestration workflows.
 
+## GitHub Actions automation
+
+This repository now ships with a **PR Automation** workflow that can be triggered
+manually to create pull requests, approve them, or run smoke tests against an
+open PR. Launch it from the **Actions** tab and choose the desired `create`,
+`approve`, or `run-tests` action. The workflow executes with read/write
+permissions across repository scopes so the GitHub CLI can manage pull requests
+on your behalf.
+
 ## XML multi-agent builder
 
 `build_model_xml.sh` coordinates researcher and architect sub-agents using
@@ -17,6 +26,18 @@ execute:
 chmod +x build_model_xml.sh
 ./build_model_xml.sh
 ```
+
+### One-liner cheat sheet
+
+The following shell snippets capture common operations end-to-end:
+
+| Goal | Command |
+| --- | --- |
+| Install publishing dependencies | `python -m pip install --upgrade huggingface_hub` |
+| Generate an MCP catalogue with the default servers | `python configure_spaces_mcp.py` |
+| Run the XML multi-agent builder | `./build_model_xml.sh` |
+| Trigger the shell-based model builder | `./build_model.sh` |
+| Publish the generated model artifact to Hugging Face (requires `huggingface_hub`) | `huggingface-cli upload <namespace>/<repo> TermuxOmniModel_core.sh.py` |
 
 Optional environment variables:
 

--- a/configure_spaces_mcp.py
+++ b/configure_spaces_mcp.py
@@ -67,6 +67,26 @@ POPULAR_SPACES: List[SpaceServer] = [
         ),
     ),
     SpaceServer(
+        space_id="modelcontextprotocol/sequential-thinking",
+        display_name="sequential-thinking",
+        transport="command",
+        entrypoint="npx -y @modelcontextprotocol/server-sequential-thinking",
+        description=(
+            "Reference implementation of the Sequential Thinking MCP server, ideal for"
+            " experimenting with tool-initiated sub-tasks and plan/act loops."
+        ),
+    ),
+    SpaceServer(
+        space_id="modelcontextprotocol/memory",
+        display_name="memory",
+        transport="command",
+        entrypoint="npx -y @modelcontextprotocol/server-memory",
+        description=(
+            "Demonstration MCP server that surfaces read/write memory primitives for"
+            " stateful agent experimentation."
+        ),
+    ),
+    SpaceServer(
         space_id="meta-llama/llama-3-8b-instruct",
         display_name="llama-3-8b-chat",
         transport="http",


### PR DESCRIPTION
## Summary
- add a manually triggered PR automation workflow that can create pull requests, approve them, or run smoke tests with full read/write permissions
- extend the MCP configuration generator with sequential-thinking and memory reference servers from the Model Context Protocol suite
- document the workflow in the README and provide one-line commands for installing deps, running builders, and publishing models to Hugging Face

## Testing
- python -m compileall configure_spaces_mcp.py
- python configure_spaces_mcp.py --list-only

------
https://chatgpt.com/codex/tasks/task_b_68e547b1d7748321a45851fdcd0a7f5b